### PR TITLE
build server netclient in testing environment

### DIFF
--- a/qa/terraform/branchterraform/clients.tf
+++ b/qa/terraform/branchterraform/clients.tf
@@ -20,7 +20,7 @@ resource "digitalocean_droplet" "clients" {
   provisioner "remote-exec" {
     inline = [
       "export PATH=$PATH:/usr/bin",
-      # install netmaker
+      # install netclient
       "apt-get -y update",
       "apt-get -y update",
       "snap install go --classic",
@@ -32,7 +32,7 @@ resource "digitalocean_droplet" "clients" {
       "git checkout ${var.clientbranch}",
       "git pull origin ${var.clientbranch}",
       "go mod tidy",
-      "go build -tags headless",
+      "go build .",
       "./netclient install"
     ]
   }

--- a/qa/terraform/branchterraform/egress.tf
+++ b/qa/terraform/branchterraform/egress.tf
@@ -36,7 +36,7 @@ resource "digitalocean_droplet" "egress" {
       "git checkout ${var.clientbranch}",
       "git pull origin ${var.clientbranch}",
       "go mod tidy",
-      "go build -tags headless",
+      "go build .",
       "./netclient install"
 
     ]

--- a/qa/terraform/branchterraform/serverdroplet.tf
+++ b/qa/terraform/branchterraform/serverdroplet.tf
@@ -18,7 +18,21 @@ resource "null_resource" "terraformnetmakerserver" {
       "wget https://raw.githubusercontent.com/gravitl/netmaker/${var.branch}/scripts/nm-quick.sh",
       "chmod +x nm-quick.sh",
       "chmod +x nm-quick.sh",
-      "bash nm-quick.sh -a -b local -t ${var.branch} -d ${var.server}.clustercat.com"
+      "bash nm-quick.sh -a -b local -t ${var.branch} -d ${var.server}.clustercat.com",
+      "snap install go --classic",
+      "snap install go --classic",
+      "apt install -y wireguard-tools gcc",
+      "apt install -y wireguard-tools gcc",
+      #remove the netcleint binary fetched from install script. running twice to ensure removal.
+      "rm netclient",
+      "rm netclient",
+      "git clone https://www.github.com/gravitl/netclient",
+      "cd netclient",
+      "git checkout ${var.clientbranch}",
+      "git pull origin ${var.clientbranch}",
+      "go mod tidy",
+      "go build .",
+      "./netclient install"
       
     ]
   }


### PR DESCRIPTION
added commands to build netclient on server for testing instead of latest release. also removed old headless tags that are not needed in the go build command